### PR TITLE
fix waitpid

### DIFF
--- a/kernel/src/process/exit.rs
+++ b/kernel/src/process/exit.rs
@@ -264,12 +264,12 @@ fn do_waitpid(
             if let Some(infop) = &mut kwo.ret_info {
                 *infop = WaitIdInfo {
                     pid,
-                    status: status as i32,
+                    status: (status as i32) << 8,
                     cause: SigChildCode::Exited.into(),
                 };
             }
 
-            kwo.ret_status = status as i32;
+            kwo.ret_status = (status as i32) << 8;
 
             child_pcb.clear_pg_and_session_reference();
             drop(child_pcb);


### PR DESCRIPTION
- 补充了SYS_EXIT_GROUP的实现
- 修正了wstatus的实现，将正常退出码向左移动8位
- 支持waitpid